### PR TITLE
(1.0.3) Fix `react-usedapp` build config, update demo applications

### DIFF
--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@erc-3643/react-usedapp": "*",
+    "@erc-3643/react-usedapp": "^1.0.3",
     "@mui/material": "^5.14.9",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/apps/demo-react/src/Content/EligibilityVerificationHolderInfo/EligibilityVerificationHolderInfo.tsx
+++ b/apps/demo-react/src/Content/EligibilityVerificationHolderInfo/EligibilityVerificationHolderInfo.tsx
@@ -1,4 +1,4 @@
-import EligibilityVerificationHolder from '@erc-3643/react-usedapp/src/components/EligibilityVerification/EligibilityVerification'
+import { EligibilityVerificationHolder } from '@erc-3643/react-usedapp'
 import { useSigner } from '@usedapp/core'
 import { Signer } from '@ethersproject/abstract-signer'
 import { useEffect, useState } from 'react'

--- a/apps/demo-vue/package.json
+++ b/apps/demo-vue/package.json
@@ -8,7 +8,7 @@
 	},
 	"dependencies": {
 		"@coinbase/wallet-sdk": "3.1.0",
-		"@erc-3643/vue-usedapp": "*",
+		"@erc-3643/vue-usedapp": "^1.0.3",
 		"@gnosis.pm/safe-apps-provider": "^0.15.1",
 		"@gnosis.pm/safe-apps-sdk": "^7.8.0",
 		"@k90mirzaei/vue-toast": "^1.0.3",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "packages": [
     "packages/@erc-3643/*"
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-root",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/@erc-3643/core/package.json
+++ b/packages/@erc-3643/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc-3643/core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Core library for ERC 3643 UI components.",
   "keywords": [
     "ERC3643",

--- a/packages/@erc-3643/react-useDapp/index.ts
+++ b/packages/@erc-3643/react-useDapp/index.ts
@@ -1,2 +1,3 @@
 import 'reflect-metadata';
 export * from "./src/hooks";
+export * from "./src/components";

--- a/packages/@erc-3643/react-useDapp/package.json
+++ b/packages/@erc-3643/react-useDapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc-3643/react-usedapp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "React components for ERC3643 interaction",
   "keywords": [
     "ERC3643",
@@ -21,7 +21,7 @@
   "author": "ERC 3643 association <contact@erc3643.org>",
   "license": "MIT",
   "dependencies": {
-    "@erc-3643/core": "^1.0.1",
+    "@erc-3643/core": "^1.0.3",
     "reflect-metadata": "^0.1.13"
   },
   "peerDependencies": {

--- a/packages/@erc-3643/react-useDapp/src/components/EligibilityVerification/EligibilityVerification.tsx
+++ b/packages/@erc-3643/react-useDapp/src/components/EligibilityVerification/EligibilityVerification.tsx
@@ -2,7 +2,7 @@ import { providers, Signer } from "ethers";
 import { useEligibilityVerificationHolder } from "../../hooks";
 import { useEffect, useState } from "react";
 
-const EligibilityVerificationHolder = ({
+export const EligibilityVerificationHolder = ({
   tokenAddress,
   walletAddress,
   signer,
@@ -58,5 +58,3 @@ const EligibilityVerificationHolder = ({
     </div>
   );
 };
-
-export default EligibilityVerificationHolder;

--- a/packages/@erc-3643/react-useDapp/src/components/EligibilityVerification/index.ts
+++ b/packages/@erc-3643/react-useDapp/src/components/EligibilityVerification/index.ts
@@ -1,0 +1,1 @@
+export * from "./EligibilityVerification";

--- a/packages/@erc-3643/react-useDapp/src/components/index.ts
+++ b/packages/@erc-3643/react-useDapp/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./EligibilityVerification";

--- a/packages/@erc-3643/vue-useDapp/package.json
+++ b/packages/@erc-3643/vue-useDapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc-3643/vue-usedapp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "VueJS components for ERC3643 interaction",
   "keywords": [
     "ERC3643",
@@ -21,7 +21,7 @@
   "author": "ERC 3643 association <contact@erc3643.org>",
   "license": "MIT",
   "dependencies": {
-    "@erc-3643/core": "^1.0.1",
+    "@erc-3643/core": "^1.0.3",
     "reflect-metadata": "^0.1.13"
   },
   "peerDependencies": {

--- a/uniswap-interface/craco.config.cjs
+++ b/uniswap-interface/craco.config.cjs
@@ -1,7 +1,6 @@
 /* eslint-env node */
 const { VanillaExtractPlugin } = require('@vanilla-extract/webpack-plugin')
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
-const { execSync } = require('child_process')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const path = require('path')
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin')
@@ -9,7 +8,8 @@ const TerserPlugin = require('terser-webpack-plugin')
 const { IgnorePlugin, ProvidePlugin } = require('webpack')
 const { RetryChunkLoadPlugin } = require('webpack-retry-chunk-load-plugin')
 
-const commitHash = execSync('git rev-parse HEAD').toString().trim()
+// https://github.com/Uniswap/interface/tree/6798bf3cf1a4bb28ba0f629cc6a48167d7b8bee9
+const commitHash = '6798bf3cf1a4bb28ba0f629cc6a48167d7b8bee9'
 const isProduction = process.env.NODE_ENV === 'production'
 
 process.env.REACT_APP_GIT_COMMIT_HASH = commitHash

--- a/uniswap-interface/package.json
+++ b/uniswap-interface/package.json
@@ -168,6 +168,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.2",
     "@coinbase/wallet-sdk": "^3.6.4",
+    "@erc-3643/react-usedapp": "*",
     "@fontsource/ibm-plex-mono": "^4.5.1",
     "@fontsource/inter": "^4.5.1",
     "@graphql-codegen/cli": "^3.3.1",

--- a/uniswap-interface/package.json
+++ b/uniswap-interface/package.json
@@ -168,7 +168,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.2",
     "@coinbase/wallet-sdk": "^3.6.4",
-    "@erc-3643/react-usedapp": "*",
+    "@erc-3643/react-usedapp": "^1.0.3",
     "@fontsource/ibm-plex-mono": "^4.5.1",
     "@fontsource/inter": "^4.5.1",
     "@graphql-codegen/cli": "^3.3.1",

--- a/uniswap-interface/yarn.lock
+++ b/uniswap-interface/yarn.lock
@@ -1714,6 +1714,22 @@
   resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@erc-3643/core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@erc-3643/core/-/core-1.0.1.tgz#82a67f12018c084ff5e4191271ca7928876a8e89"
+  integrity sha512-5c+sufQESdSFUZb3ubC3fT+wlG01lvAl/33X/5b6Q4Wipk7VoIixk/JMjNKD9g67B5X3/4MtvkJhGCtcb8Ly8g==
+  dependencies:
+    reflect-metadata "^0.1.13"
+    typedi "^0.10.0"
+
+"@erc-3643/react-usedapp@*":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@erc-3643/react-usedapp/-/react-usedapp-1.0.1.tgz#3a42cc9e4d0ad71b66eca497ed842a4befadb290"
+  integrity sha512-ShYIQ6chlQWV2iWV8S9YlaOJlFPmvHkqCIGZXi0XK6wGI5wCNL0CfwkJuC61D91vkpb9gPar1CZnwgDLQKKQ1g==
+  dependencies:
+    "@erc-3643/core" "^1.0.1"
+    reflect-metadata "^0.1.13"
+
 "@esbuild-plugins/node-globals-polyfill@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz#0e4497a2b53c9e9485e149bc92ddb228438d6bcf"
@@ -17789,6 +17805,11 @@ redux@^4.0.0, redux@^4.1.2, redux@^4.2.1:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
+reflect-metadata@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
+
 reflexbox@^4.0.6:
   version "4.0.6"
   resolved "https://registry.npmjs.org/reflexbox/-/reflexbox-4.0.6.tgz"
@@ -19942,6 +19963,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typedi@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/typedi/-/typedi-0.10.0.tgz#e8f9a5ee100b84addbdfb57fe90d8d9ed2a21dea"
+  integrity sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w==
 
 typescript@^4.9.4:
   version "4.9.5"


### PR DESCRIPTION
- Bumped packages versions
- Bumped demo applications dependencies versions
- Added named export to `react-usedapp` for components
- Updated `uniswap-interface` craco config to be able to launch it locally